### PR TITLE
Add support for global per resource rules

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -251,6 +251,22 @@ of a department (or person) given all access to all resources in your company:
         },
     }
 
+=head2 All entities
+
+All entities can access the public resource:
+
+	my $auth = Authorize::Rule->new(
+            default => 0,
+            rules   => {
+                'Person' => {
+                    'place' => [ [ 1 ] ]
+                },
+                '' => {
+                    'public'     => [ [ 1 ] ],
+                    ''          => [ [ 1 ] ], # ignored, we have a $default for that
+                    }
+    });
+
 =head2 Per resource
 
 Dogs, however, provide less of a problem. Mostly if you tell them they aren't

--- a/lib/Authorize/Rule.pm
+++ b/lib/Authorize/Rule.pm
@@ -101,19 +101,27 @@ sub allowed {
         params   => $req_params,
     );
 
+    my $perms = $rules->{$entity} || {};
+    # perms for all the entities.
+    my $all_entities_perms = $rules->{''} || {};
+
     # deny entities that aren't in the rules
-    my $perms = $rules->{$entity}
+    $perms || $all_entities_perms
         or return { %result, action => $default };
 
     # the requested and default
     my $main_ruleset = $perms->{$req_resource} || [];
     my $def_ruleset  = $perms->{''}            || [];
 
+    # perm for all the entities. Lower priority than main&def ruleset
+    # we don't need to check $all_entities_perms->{''} because we have $default
+    my $all_entities_ruleset = $all_entities_perms->{$req_resource} || [];
+
     # if neither, return default action
-    @{ $main_ruleset } || @{ $def_ruleset }
+    @{ $main_ruleset } || @{ $def_ruleset } || @{ $all_entities_ruleset }
         or return { %result, action => $default };
 
-    foreach my $rulesets ( $main_ruleset, $def_ruleset ) {
+    foreach my $rulesets ( $main_ruleset, $def_ruleset, $all_entities_ruleset) {
         my $ruleset_idx = 0;
         my $label;
 

--- a/t/api/all-entities.t
+++ b/t/api/all-entities.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+use Authorize::Rule;
+
+my $auth = Authorize::Rule->new(
+    default => 0,
+    rules   => {
+        'Person' => {
+            'place' => [ [ 1 ] ]
+        },
+        '' => {
+            'public'     => [ [ 1 ] ],
+            ''           => [ [ 1 ] ], # ignored
+        }
+    },
+);
+
+isa_ok( $auth, 'Authorize::Rule' );
+
+ok(
+    $auth->is_allowed( 'Person', 'place' ),
+    'Person allowed to enter Place',
+);
+
+ok(
+    ! $auth->is_allowed( 'Foo', 'place' ),
+    'Foo is not allowed in Place',
+);
+
+ok(
+    $auth->is_allowed( 'Person', 'public' ),
+    'Person is allowed in the public place'
+);
+
+ok(
+    $auth->is_allowed( 'Foo', 'public' ),
+    'Foo is allowed in the public place',
+);
+
+ok(
+    ! $auth->is_allowed( 'Person', 'not_public'),
+    'Person not allowed in the not_public place(default rule)',
+);
+


### PR DESCRIPTION
These rules apply to all the entities.
They follow the same convention as the rules for all the resources('' is
"all") and have lower priority than the specific rules.
